### PR TITLE
Remove unneeded closing tags on images.

### DIFF
--- a/about.html
+++ b/about.html
@@ -14,14 +14,10 @@
                 <a href="contact.html"><img src="images/contact_250714.png"></a>
             </div>
             <div class="flex-row">
-                <img src="images/meet_the_team_250730.png"
-                     style="margin: 10px;"
-                     width="20%"</img>
+                <img src="images/meet_the_team_250730.png" style="margin: 10px;" width="20%">
             </div>
             <div class="flex-row">
-                <img src="images/tony_250717.png"
-                     style="margin: 40px;"
-                     width="35%"</img>
+                <img src="images/tony_250717.png" style="margin: 40px;" width="35%">
                 <p style="font-size: 20px; width: 50%;">
                     Anthony "Tony" Pascarelli is the Owner and Head Chef of Grody's Italian Bistro.
                     Tony has been awarded the Boughton Culture & Quality Award at the Danbury
@@ -40,9 +36,7 @@
                 </p>
             </div>
             <div class="flex-row">
-                <img src="images/sergio_250717.png"
-                     style="margin: 40px;"
-                     width="35%"</img>
+                <img src="images/sergio_250717.png" style="margin: 40px;" width="35%">
                 <p style="font-size: 20px; width: 50%;">
                     Sergio Bagali is the Head Server and Assistant Manager at Grody's Italian
                     Bistro. Sergio was born and raised in Città della Pieve, Umbria, Italy. When
@@ -57,9 +51,7 @@
                 </p>
             </div>
             <div class="flex-row">
-                <img src="images/marcos_250717.png"
-                     style="margin: 40px;"
-                     width="35%"</img>
+                <img src="images/marcos_250717.png" style="margin: 40px;" width="35%">
                 <p style="font-size: 20px; width: 50%;">
                     Marcos Depanner is the Busboy and Greeter for Grody's Italian Bistro. A
                     full-time member of the team since the restaurant's opening in 2013, Marcos has

--- a/menu.html
+++ b/menu.html
@@ -15,66 +15,66 @@
             </div>
             <div class="flex-row">
                 <div class="flex-column">
-                    <img src="images/eggs_and_clam_calzone_250717.png" style="margin: 20;"</img>
+                    <img src="images/eggs_and_clam_calzone_250717.png" style="margin: 20;">
                 </div>
                 <div class="flex-column">
-                    <img src="images/pickle_and_venison_calzone_250717.png" style="margin: 20;"</img>
-                </div>
-            </div>
-            <div class="flex-row">
-                <div class="flex-column">
-                    <img src="images/vodka_escargot_calzone_250719.png" style="margin: 20;"</img>
-                </div>
-                <div class="flex-column">
-                    <img src="images/horseradish_risotto_250719.png" style="margin: 20;"</img>
+                    <img src="images/pickle_and_venison_calzone_250717.png" style="margin: 20;">
                 </div>
             </div>
             <div class="flex-row">
                 <div class="flex-column">
-                    <img src="images/grouper_pesto_calzone_250720.png" style="margin: 20;"</img>
+                    <img src="images/vodka_escargot_calzone_250719.png" style="margin: 20;">
                 </div>
                 <div class="flex-column">
-                    <img src="images/virginia_bear_tenderloin_250720.png" style="margin: 20;"</img>
-                </div>
-            </div>
-            <div class="flex-row">
-                <div class="flex-column">
-                    <img src="images/applesauce_parmesan_250718.png" style="margin: 20;"</img>
-                </div>
-                <div class="flex-column">
-                    <img src="images/non_alcoholic_hot_dog_250718.png" style="margin: 20;"</img>
+                    <img src="images/horseradish_risotto_250719.png" style="margin: 20;">
                 </div>
             </div>
             <div class="flex-row">
                 <div class="flex-column">
-                    <img src="images/house_salad_with_black_mangrove_vinaigrette_250719.png" style="margin: 20;"</img>
+                    <img src="images/grouper_pesto_calzone_250720.png" style="margin: 20;">
                 </div>
                 <div class="flex-column">
-                    <img src="images/chef_tonys_salad_250720.png" style="margin: 20;"</img>
+                    <img src="images/virginia_bear_tenderloin_250720.png" style="margin: 20;">
                 </div>
             </div>
             <div class="flex-row">
                 <div class="flex-column">
-                    <img src="images/garlic_martini_250718.png" style="margin: 20;"</img>
+                    <img src="images/applesauce_parmesan_250718.png" style="margin: 20;">
                 </div>
                 <div class="flex-column">
-                    <img src="images/new_haven_clamerita_250718.png" style="margin: 20;"</img>
+                    <img src="images/non_alcoholic_hot_dog_250718.png" style="margin: 20;">
+                </div>
+            </div>
+            <div class="flex-row">
+                <div class="flex-column">
+                    <img src="images/house_salad_with_black_mangrove_vinaigrette_250719.png" style="margin: 20;">
+                </div>
+                <div class="flex-column">
+                    <img src="images/chef_tonys_salad_250720.png" style="margin: 20;">
+                </div>
+            </div>
+            <div class="flex-row">
+                <div class="flex-column">
+                    <img src="images/garlic_martini_250718.png" style="margin: 20;">
+                </div>
+                <div class="flex-column">
+                    <img src="images/new_haven_clamerita_250718.png" style="margin: 20;">
                 </div>
             </div>
 	    <div class="flex-row">
                 <div class="flex-column">
-                    <img src="images/balsamic_mojito_250731.png" style="margin: 20;"</img>
+                    <img src="images/balsamic_mojito_250731.png" style="margin: 20;">
                 </div>
                 <div class="flex-column">
-                    <img src="images/cacio_e_paloma_250731.png" style="margin: 20;"</img>
+                    <img src="images/cacio_e_paloma_250731.png" style="margin: 20;">
                 </div>
             </div>
             <div class="flex-row">
                 <div class="flex-column">
-                    <img src="images/long_island_parmesan_iced_tea_250731.png" style="margin: 20;"</img>
+                    <img src="images/long_island_parmesan_iced_tea_250731.png" style="margin: 20;">
                 </div>
                 <div class="flex-column">
-                    <img src="pimento_and_yolk_old_fashioned_250731.png" style="margin: 20;"</img>
+                    <img src="pimento_and_yolk_old_fashioned_250731.png" style="margin: 20;">
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Various documentation sources (e.g. [geeksforgeeks](https://www.geeksforgeeks.org/html/html-img-tag/)) for the `img` element point out that the element is self-closing and cannot contain anything. This means that my closing tags `</img>` are unneeded and can be removed.